### PR TITLE
Fix mismatching 'less than' operators

### DIFF
--- a/sqlalchemy_django_query.py
+++ b/sqlalchemy_django_query.py
@@ -38,9 +38,9 @@ class DjangoQueryMixin(object):
     """
     _underscore_operators = {
         'gt':           operators.gt,
-        'lte':          operators.lt,
+        'lt':           operators.lt,
         'gte':          operators.ge,
-        'le':           operators.le,
+        'lte':          operators.le,
         'contains':     operators.contains_op,
         'in':           operators.in_op,
         'exact':        operators.eq,


### PR DESCRIPTION
Should be 'lt' instead of 'le' to match Django:
https://docs.djangoproject.com/en/1.4/ref/models/querysets/#lt

Fixes issue #1

Many thanks.
